### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,6 +232,8 @@ jobs:
       - build
     if: ${{ needs.build.result == 'success' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/luizfonseca/proksi/security/code-scanning/5](https://github.com/luizfonseca/proksi/security/code-scanning/5)

To fix the issue, we need to add a `permissions` block to the `upload-artifacts` job in the workflow file. This block should specify the least privileges required for the job to function correctly. Based on the job's functionality, it likely requires `contents: write` to upload release artifacts. If additional permissions are needed, they should be explicitly listed.

The changes will be made to the `.github/workflows/release.yml` file, specifically within the `upload-artifacts` job definition. No new dependencies are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
